### PR TITLE
Add support for fraktur and framed exotic ansi modes

### DIFF
--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -33,6 +33,8 @@ type Action
     | SetUnderline Bool
     | SetBlink Bool
     | SetInverted Bool
+    | SetFraktur Bool
+    | SetFramed Bool
     | Linebreak
     | CarriageReturn
     | CursorUp Int
@@ -315,6 +317,9 @@ codeActions code =
         7 ->
             [ SetInverted True ]
 
+        20 ->
+            [ SetFraktur True ]
+
         30 ->
             [ SetForeground (Just Black) ]
 
@@ -368,6 +373,9 @@ codeActions code =
 
         49 ->
             [ SetBackground Nothing ]
+
+        51 ->
+            [ SetFramed True ]
 
         90 ->
             [ SetForeground (Just BrightBlack) ]
@@ -431,4 +439,6 @@ reset =
     , SetUnderline False
     , SetBlink False
     , SetInverted False
+    , SetFraktur False
+    , SetFramed False
     ]

--- a/src/Ansi/Log.elm
+++ b/src/Ansi/Log.elm
@@ -59,6 +59,8 @@ type alias Style =
     , underline : Bool
     , blink : Bool
     , inverted : Bool
+    , fraktur : Bool
+    , framed : Bool
     }
 
 
@@ -99,6 +101,8 @@ init ldisc =
         , underline = False
         , blink = False
         , inverted = False
+        , fraktur = False
+        , framed = False
         }
     , remainder = ""
     }
@@ -252,6 +256,12 @@ updateStyle action style =
 
         Ansi.SetBlink b ->
             { style | blink = b }
+
+        Ansi.SetFraktur b ->
+            { style | fraktur = b }
+
+        Ansi.SetFramed b ->
+            { style | framed = b }
 
         _ ->
             style
@@ -464,7 +474,8 @@ styleAttributes style =
             List.map (flip (,) True) (fgClasses ++ bgClasses)
 
         ansiClasses =
-            [ ( "ansi-blink", style.blink ), ( "ansi-faint", style.faint ) ]
+            [ ( "ansi-blink", style.blink ), ( "ansi-faint", style.faint ),
+              ( "ansi-Fraktur", style.fraktur ), ( "ansi-framed", style.framed)  ]
       in
         Html.Attributes.classList (fgbgClasses ++ ansiClasses)
     ]


### PR DESCRIPTION
Adds detect and classes for fraktur (code 20) and framed (code 51). Both are useful with a follow-on PR to have concourse render them nicely.