### PR TITLE
Fix failing tests

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -62,6 +62,8 @@ parsing =
                     , Ansi.SetUnderline False
                     , Ansi.SetBlink False
                     , Ansi.SetInverted False
+                    , Ansi.SetFraktur False
+                    , Ansi.SetFramed False
                     , Ansi.Print "reset"
                     , Ansi.SetForeground Nothing
                     , Ansi.SetBackground Nothing
@@ -71,6 +73,8 @@ parsing =
                     , Ansi.SetUnderline False
                     , Ansi.SetBlink False
                     , Ansi.SetInverted False
+                    , Ansi.SetFraktur False
+                    , Ansi.SetFramed False
                     , Ansi.Print "reset again"
                     , Ansi.SetForeground Nothing
                     , Ansi.SetBackground Nothing
@@ -80,6 +84,8 @@ parsing =
                     , Ansi.SetUnderline False
                     , Ansi.SetBlink False
                     , Ansi.SetInverted False
+                    , Ansi.SetFraktur False
+                    , Ansi.SetFramed False
                     , Ansi.SetForeground (Just Ansi.Red)
                     , Ansi.Print "reset to red"
                     ]


### PR DESCRIPTION
The `resetting` test was missing "fraktur" and "framed".