### PR TITLE
Add support for color codes with arguments

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -31,6 +31,20 @@ parsing =
                     , Ansi.Print "bright green bg"
                     ]
                     (Ansi.parse "normal\u{001B}[31mred fg\u{001B}[42mgreen bg\u{001B}[91mbright red fg\u{001B}[102mbright green bg")
+        , test "single argument colors" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "normal"
+                    , Ansi.SetForeground (Just Ansi.Red)
+                    , Ansi.Print "red fg"
+                    , Ansi.SetBackground (Just Ansi.Green)
+                    , Ansi.Print "green bg"
+                    , Ansi.SetForeground (Just Ansi.BrightRed)
+                    , Ansi.Print "bright red fg"
+                    , Ansi.SetBackground (Just Ansi.BrightGreen)
+                    , Ansi.Print "bright green bg"
+                    ]
+                    (Ansi.parse "normal\u{001B}[38;5;1mred fg\u{001B}[48;5;2mgreen bg\u{001B}[38;5;9mbright red fg\u{001B}[48;5;10mbright green bg")
         , test "text styling" <|
             \() ->
                 Expect.equal


### PR DESCRIPTION
I found that in outputs using fg/bg colors with argument syntax were being misinterpreted.

`38;5;3` should be interpreted as:
- 38: Set foreground color
- 5: observe next value as argument
- 3: standard intensity yellow

but instead was being interpreted as:
- 38: ignored
- 5: set blink to true
- 3: set italic to true

This PR adds checks for code 38 and 48 for foreground and background color respectively. The `captureArguments` function sets a precedent for other argument-taking codes unrelated to colors.