### PR TITLE
Support 8-bit and 24-bit colours

### DIFF
--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -73,6 +73,7 @@ type Color
     | BrightMagenta
     | BrightCyan
     | BrightWhite
+    | Custom Int Int Int
 
 
 {-| Method to erase the display or line.
@@ -149,32 +150,116 @@ encodeCode code =
         Just num ->
             String.fromInt num
 
-{-| Offsets SGR argument number to equivalent standard and high intensity ESC code
+
+{-| Converts a color code to an 8-bit color per
+<https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit>
 -}
-offsetColorCode : Int -> Int -> Int
-offsetColorCode code offset =
-    -- standard
-    if code >= 0 && code < 8 then code + offset
+colorCode : Int -> Maybe Color
+colorCode code =
+    case code of
+        0 ->
+            Just Black
 
-    -- high intensity
-    else if code >= 8  && code < 16 then code + offset + 52
+        1 ->
+            Just Red
 
-    else code
+        2 ->
+            Just Green
+
+        3 ->
+            Just Yellow
+
+        4 ->
+            Just Blue
+
+        5 ->
+            Just Magenta
+
+        6 ->
+            Just Cyan
+
+        7 ->
+            Just White
+
+        8 ->
+            Just BrightBlack
+
+        9 ->
+            Just BrightRed
+
+        10 ->
+            Just BrightGreen
+
+        11 ->
+            Just BrightYellow
+
+        12 ->
+            Just BrightBlue
+
+        13 ->
+            Just BrightMagenta
+
+        14 ->
+            Just BrightCyan
+
+        15 ->
+            Just BrightWhite
+
+        _ ->
+            if code >= 16 && code < 232 then
+                let
+                    c =
+                        code - 16
+
+                    b =
+                        modBy 6 c
+
+                    g =
+                        modBy 6 (c // 6)
+
+                    r =
+                        modBy 6 ((c // 6) // 6)
+
+                    -- Scales [0,5] -> [0,255] (not uniformly)
+                    -- 0     1     2     3     4     5
+                    -- 0    95   135   175   215   255
+                    scale n =
+                        if n == 0 then
+                            0
+
+                        else
+                            55 + n * 40
+                in
+                Just <| Custom (scale r) (scale g) (scale b)
+
+            else if code >= 232 && code < 256 then
+                let
+                    -- scales [232,255] -> [8,238]
+                    c =
+                        (code - 232) * 10 + 8
+                in
+                Just <| Custom c c c
+
+            else
+                Nothing
+
 
 {-| Capture SGR arguments in pattern match
 -}
 captureArguments : List Int -> List Action
 captureArguments list =
     case list of
-        -- foreground colors
-        38 :: 5 :: n :: xs -> codeActions (offsetColorCode n 30) ++ captureArguments xs
+        38 :: 5 :: n :: xs ->
+            SetForeground (colorCode n) :: captureArguments xs
 
-        -- background colors
-        48 :: 5 :: n :: xs -> codeActions (offsetColorCode n 40) ++ captureArguments xs
+        48 :: 5 :: n :: xs ->
+            SetBackground (colorCode n) :: captureArguments xs
 
-        n :: xs -> codeActions n ++ captureArguments xs
+        n :: xs ->
+            codeActions n ++ captureArguments xs
 
-        [] -> []
+        [] ->
+            []
 
 
 parseChar : String -> Parser a -> Parser a
@@ -206,7 +291,8 @@ parseChar char parser =
             case char of
                 "m" ->
                     completeBracketed parser <|
-                        captureArguments <| List.map (Maybe.withDefault 0) (codes ++ [ currentCode ])
+                        captureArguments <|
+                            List.map (Maybe.withDefault 0) (codes ++ [ currentCode ])
 
                 "A" ->
                     completeBracketed parser

--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -255,6 +255,20 @@ captureArguments list =
         48 :: 5 :: n :: xs ->
             SetBackground (colorCode n) :: captureArguments xs
 
+        38 :: 2 :: r :: g :: b :: xs ->
+            let
+                c =
+                    clamp 0 255
+            in
+            SetForeground (Just <| Custom (c r) (c g) (c b)) :: captureArguments xs
+
+        48 :: 2 :: r :: g :: b :: xs ->
+            let
+                c =
+                    clamp 0 255
+            in
+            SetBackground (Just <| Custom (c r) (c g) (c b)) :: captureArguments xs
+
         n :: xs ->
             codeActions n ++ captureArguments xs
 

--- a/src/Ansi/Log.elm
+++ b/src/Ansi/Log.elm
@@ -456,6 +456,27 @@ viewChunk chunk =
 
 styleAttributes : Style -> List (Html.Attribute x)
 styleAttributes style =
+    let
+        fgStyles =
+            colorStyles True
+                style.bold
+                (if not style.inverted then
+                    style.foreground
+
+                 else
+                    style.background
+                )
+
+        bgStyles =
+            colorStyles False
+                style.bold
+                (if not style.inverted then
+                    style.background
+
+                 else
+                    style.foreground
+                )
+    in
     [ Html.Attributes.style "font-weight"
         (if style.bold then
             "bold"
@@ -477,44 +498,27 @@ styleAttributes style =
          else
             "normal"
         )
-    , let
-        fgClasses =
-            colorClasses "-fg"
-                style.bold
-                (if not style.inverted then
-                    style.foreground
-
-                 else
-                    style.background
-                )
-
-        bgClasses =
-            colorClasses "-bg"
-                style.bold
-                (if not style.inverted then
-                    style.background
-
-                 else
-                    style.foreground
-                )
-
-        fgbgClasses =
-            List.map (\a -> (\b c -> ( b, c )) a True) (fgClasses ++ bgClasses)
-
-        ansiClasses =
-            [ ( "ansi-blink", style.blink )
-            , ( "ansi-faint", style.faint )
-            , ( "ansi-Fraktur", style.fraktur )
-            , ( "ansi-framed", style.framed )
-            ]
-      in
-      Html.Attributes.classList (fgbgClasses ++ ansiClasses)
+    , Html.Attributes.classList
+        [ ( "ansi-blink", style.blink )
+        , ( "ansi-faint", style.faint )
+        , ( "ansi-Fraktur", style.fraktur )
+        , ( "ansi-framed", style.framed )
+        ]
     ]
+        ++ fgStyles
+        ++ bgStyles
 
 
-colorClasses : String -> Bool -> Maybe Ansi.Color -> List String
-colorClasses suffix bold mc =
+colorStyles : Bool -> Bool -> Maybe Ansi.Color -> List (Html.Attribute x)
+colorStyles fg bold mc =
     let
+        suffix =
+            if fg then
+                "-fg"
+
+            else
+                "-bg"
+
         brightPrefix =
             "ansi-bright-"
 
@@ -524,59 +528,84 @@ colorClasses suffix bold mc =
 
             else
                 "ansi-"
+
+        class name =
+            [ Html.Attributes.class (prefix ++ name ++ suffix) ]
+
+        brightClass name =
+            [ Html.Attributes.class (brightPrefix ++ name ++ suffix) ]
     in
     case mc of
         Nothing ->
             if bold then
-                [ "ansi-bold" ]
+                [ Html.Attributes.class "ansi-bold" ]
 
             else
                 []
 
         Just Ansi.Black ->
-            [ prefix ++ "black" ++ suffix ]
+            class "black"
 
         Just Ansi.Red ->
-            [ prefix ++ "red" ++ suffix ]
+            class "red"
 
         Just Ansi.Green ->
-            [ prefix ++ "green" ++ suffix ]
+            class "green"
 
         Just Ansi.Yellow ->
-            [ prefix ++ "yellow" ++ suffix ]
+            class "yellow"
 
         Just Ansi.Blue ->
-            [ prefix ++ "blue" ++ suffix ]
+            class "blue"
 
         Just Ansi.Magenta ->
-            [ prefix ++ "magenta" ++ suffix ]
+            class "magenta"
 
         Just Ansi.Cyan ->
-            [ prefix ++ "cyan" ++ suffix ]
+            class "cyan"
 
         Just Ansi.White ->
-            [ prefix ++ "white" ++ suffix ]
+            class "white"
 
         Just Ansi.BrightBlack ->
-            [ brightPrefix ++ "black" ++ suffix ]
+            brightClass "black"
 
         Just Ansi.BrightRed ->
-            [ brightPrefix ++ "red" ++ suffix ]
+            brightClass "red"
 
         Just Ansi.BrightGreen ->
-            [ brightPrefix ++ "green" ++ suffix ]
+            brightClass "green"
 
         Just Ansi.BrightYellow ->
-            [ brightPrefix ++ "yellow" ++ suffix ]
+            brightClass "yellow"
 
         Just Ansi.BrightBlue ->
-            [ brightPrefix ++ "blue" ++ suffix ]
+            brightClass "blue"
 
         Just Ansi.BrightMagenta ->
-            [ brightPrefix ++ "magenta" ++ suffix ]
+            brightClass "magenta"
 
         Just Ansi.BrightCyan ->
-            [ brightPrefix ++ "cyan" ++ suffix ]
+            brightClass "cyan"
 
         Just Ansi.BrightWhite ->
-            [ brightPrefix ++ "white" ++ suffix ]
+            brightClass "white"
+
+        Just (Ansi.Custom r g b) ->
+            let
+                attr =
+                    if fg then
+                        "color"
+
+                    else
+                        "background-color"
+            in
+            [ Html.Attributes.style attr <|
+                "rgb("
+                    ++ String.fromInt r
+                    ++ ","
+                    ++ String.fromInt g
+                    ++ ","
+                    ++ String.fromInt b
+                    ++ ")"
+            ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -45,6 +45,20 @@ parsing =
                     , Ansi.Print "bright green bg"
                     ]
                     (Ansi.parse "normal\u{001B}[38;5;1mred fg\u{001B}[48;5;2mgreen bg\u{001B}[38;5;9mbright red fg\u{001B}[48;5;10mbright green bg")
+        , test "8-bit colors" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "normal"
+                    , Ansi.SetForeground (Just <| Ansi.Custom 0 215 95)
+                    , Ansi.Print "green fg"
+                    , Ansi.SetBackground (Just <| Ansi.Custom 255 95 0)
+                    , Ansi.Print "orange bg"
+                    , Ansi.SetForeground (Just <| Ansi.Custom 88 88 88)
+                    , Ansi.Print "dark grey fg"
+                    , Ansi.SetBackground (Just <| Ansi.Custom 188 188 188)
+                    , Ansi.Print "light grey bg"
+                    ]
+                    (Ansi.parse "normal\u{001B}[38;5;41mgreen fg\u{001B}[48;5;202morange bg\u{001B}[38;5;240mdark grey fg\u{001B}[48;5;250mlight grey bg")
         , test "text styling" <|
             \() ->
                 Expect.equal
@@ -346,6 +360,10 @@ colorCode color =
 
         Ansi.BrightWhite ->
             67
+
+        Ansi.Custom _ _ _ ->
+            -- not supported in this format
+            -1
 
 
 log : Test

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -59,6 +59,18 @@ parsing =
                     , Ansi.Print "light grey bg"
                     ]
                     (Ansi.parse "normal\u{001B}[38;5;41mgreen fg\u{001B}[48;5;202morange bg\u{001B}[38;5;240mdark grey fg\u{001B}[48;5;250mlight grey bg")
+        , test "24-bit colors" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "normal"
+                    , Ansi.SetForeground (Just <| Ansi.Custom 123 15 51)
+                    , Ansi.Print "custom fg"
+                    , Ansi.SetBackground (Just <| Ansi.Custom 55 66 77)
+                    , Ansi.Print "custom bg"
+                    , Ansi.SetBackground (Just <| Ansi.Custom 255 0 255)
+                    , Ansi.Print "clamped"
+                    ]
+                    (Ansi.parse "normal\u{001B}[38;2;123;15;51mcustom fg\u{001B}[48;2;55;66;77mcustom bg\u{001B}[48;2;1000;0;255mclamped")
         , test "text styling" <|
             \() ->
                 Expect.equal


### PR DESCRIPTION
#7 added basic support for 8-bit colours, but only worked for basic colours (values 0-15). Per https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit:

> 16-231:  6 × 6 × 6 cube (216 colors): 16 + 36 × r + 6 × g + b (0 ≤ r, g, b ≤ 5)
> 232-255:  grayscale from black to white in 24 steps

This PR adds support for those escape sequences. It also adds support for full 24 bit colours, since it was easy - we can now make smooth gradient backgrounds in tasks if we want.

---

With the following `task.yml`:

```
platform: linux

image_resource:
  type: registry-image
  source: {repository: python}

run:
  path: python
  args:
  - -c
  - |
    def colorized8(text, n):
        print(f"\033[48;5;{n}m{text}\033[m", end='')
    
    def colorized24(text, r, g, b):
        print(f"\033[48;2;{r};{g};{b}m{text}\033[m", end='')
    
    print("8 bit")
    print("-----")
    for i in range(16):
        for j in range(16):
            colorized8("    ", i * 16 + j)
        print()
    
    print("24 bit")
    print("------")
    r = 127
    for g in range(0, 256, 4):
        for b in range(0, 256, 2):
            colorized24(" ", r, g, b)
        print()
```

With elm-ansi v9.0.2:
<img width="1072" alt="Screen Shot 2021-02-25 at 9 33 58 PM" src="https://user-images.githubusercontent.com/26583442/109247008-33636200-77b1-11eb-81da-dd7ad2ad6e14.png">

With this PR:
<img width="1080" alt="Screen Shot 2021-02-25 at 9 32 32 PM" src="https://user-images.githubusercontent.com/26583442/109247041-3eb68d80-77b1-11eb-84ca-d75f1e7c8648.png">
