### PR TITLE
support partial reset SGR parameters

### DIFF
--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -451,6 +451,28 @@ codeActions code =
         20 ->
             [ SetFraktur True ]
 
+        21 ->
+            [ SetBold False ]
+
+        22 ->
+            [ SetFaint False
+            , SetBold False
+            ]
+
+        23 ->
+            [ SetItalic False
+            , SetFraktur False
+            ]
+
+        24 ->
+            [ SetUnderline False ]
+
+        25 ->
+            [ SetBlink False ]
+
+        27 ->
+            [ SetInverted False ]
+
         30 ->
             [ SetForeground (Just Black) ]
 
@@ -507,6 +529,9 @@ codeActions code =
 
         51 ->
             [ SetFramed True ]
+
+        54 ->
+            [ SetFramed False ]
 
         90 ->
             [ SetForeground (Just BrightBlack) ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -130,6 +130,20 @@ parsing =
                     , Ansi.Print "reset to red"
                     ]
                     (Ansi.parse "some text\u{001B}[0mreset\u{001B}[mreset again\u{001B}[;31mreset to red")
+        , test "partial resetting" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "some text"
+                    , Ansi.SetBold False
+                    , Ansi.Print "not bold"
+                    , Ansi.SetFaint False
+                    , Ansi.SetBold False
+                    , Ansi.Print "not intense"
+                    , Ansi.SetItalic False
+                    , Ansi.SetFraktur False
+                    , Ansi.Print "not italic/fraktur"
+                    ]
+                    (Ansi.parse "some text\u{001B}[21mnot bold\u{001B}[22mnot intense\u{001B}[23mnot italic/fraktur")
         , test "carriage returns and linebreaks" <|
             \() ->
                 Expect.equal


### PR DESCRIPTION
From @chenbh's feedback on https://github.com/concourse/concourse/pull/6605, and referencing https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters