### PR TITLE
Add strikethrough support (ANSI codes 9/29)

### DIFF
--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -41,6 +41,7 @@ type Action
     | SetUnderline Bool
     | SetBlink Bool
     | SetInverted Bool
+    | SetStrikethrough Bool
     | SetFraktur Bool
     | SetFramed Bool
     | Linebreak
@@ -587,6 +588,9 @@ codeActions code =
         7 ->
             [ SetInverted True ]
 
+        9 ->
+            [ SetStrikethrough True ]
+
         20 ->
             [ SetFraktur True ]
 
@@ -611,6 +615,9 @@ codeActions code =
 
         27 ->
             [ SetInverted False ]
+
+        29 ->
+            [ SetStrikethrough False ]
 
         30 ->
             [ SetForeground (Just Black) ]
@@ -734,6 +741,7 @@ reset =
     , SetUnderline False
     , SetBlink False
     , SetInverted False
+    , SetStrikethrough False
     , SetFraktur False
     , SetFramed False
     ]

--- a/src/Ansi/Log.elm
+++ b/src/Ansi/Log.elm
@@ -70,6 +70,7 @@ type alias Style =
     , underline : Bool
     , blink : Bool
     , inverted : Bool
+    , strikethrough : Bool
     , fraktur : Bool
     , framed : Bool
     }
@@ -113,6 +114,7 @@ init ldisc =
         , underline = False
         , blink = False
         , inverted = False
+        , strikethrough = False
         , fraktur = False
         , framed = False
         }
@@ -285,6 +287,9 @@ updateStyle action style =
 
         Ansi.SetBlink b ->
             { style | blink = b }
+
+        Ansi.SetStrikethrough b ->
+            { style | strikethrough = b }
 
         Ansi.SetFraktur b ->
             { style | fraktur = b }
@@ -517,8 +522,14 @@ styleAttributes style =
             "normal"
         )
     , Html.Attributes.style "text-decoration"
-        (if style.underline then
+        (if style.underline && style.strikethrough then
+            "underline line-through"
+
+         else if style.underline then
             "underline"
+
+         else if style.strikethrough then
+            "line-through"
 
          else
             "none"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -84,8 +84,10 @@ parsing =
                     , Ansi.Print "fast blink"
                     , Ansi.SetInverted True
                     , Ansi.Print "inverted"
+                    , Ansi.SetStrikethrough True
+                    , Ansi.Print "strikethrough"
                     ]
-                    (Ansi.parse "normal\u{001B}[1mbold\u{001B}[2mfaint\u{001B}[3mitalic\u{001B}[4munderline\u{001B}[5mblink\u{001B}[6mfast blink\u{001B}[7minverted")
+                    (Ansi.parse "normal\u{001B}[1mbold\u{001B}[2mfaint\u{001B}[3mitalic\u{001B}[4munderline\u{001B}[5mblink\u{001B}[6mfast blink\u{001B}[7minverted\u{001B}[9mstrikethrough")
         , test "resetting styles" <|
             \() ->
                 Expect.equal
@@ -98,6 +100,7 @@ parsing =
                     , Ansi.SetUnderline False
                     , Ansi.SetBlink False
                     , Ansi.SetInverted False
+                    , Ansi.SetStrikethrough False
                     , Ansi.SetFraktur False
                     , Ansi.SetFramed False
                     , Ansi.Print "reset"


### PR DESCRIPTION
- Add SetStrikethrough action and Style field
- Implement codes 9 (on), 29 (off), and reset
- Render as CSS text-decoration: line-through
- Add test coverage