### PR TITLE
Add Unicode character width support for terminal rendering

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,10 +12,11 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm/url": "1.0.0 <= v < 2.0.0"
+        "elm/regex": "1.0.0 <= v < 2.0.0",
+        "elm/url": "1.0.0 <= v < 2.0.0",
+        "elm-explorations/benchmark": "1.0.2 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm-explorations/test": "2.2.0 <= v < 3.0.0"
     }
 }

--- a/src/Ansi/Log.elm
+++ b/src/Ansi/Log.elm
@@ -591,7 +591,7 @@ addChunk chunk line =
                             c.text ++ chunk.text
 
                         mergedWidth =
-                            stringDisplayWidth mergedText
+                            c.cachedWidth + clen
                     in
                     ( { c | text = mergedText, cachedWidth = mergedWidth } :: cs, llen + clen )
 

--- a/src/Ansi/Log.elm
+++ b/src/Ansi/Log.elm
@@ -306,9 +306,238 @@ lineLen =
     Tuple.second
 
 
+{-| Combining character ranges (zero-width) from Go runewidth package.
+-}
+combiningRanges : Array ( Int, Int )
+combiningRanges =
+    Array.fromList
+        [ ( 0x0300, 0x036F ), ( 0x0483, 0x0489 ), ( 0x07EB, 0x07F3 )
+        , ( 0x0C00, 0x0C00 ), ( 0x0C04, 0x0C04 ), ( 0x0CF3, 0x0CF3 )
+        , ( 0x0D00, 0x0D01 ), ( 0x135D, 0x135F ), ( 0x1A7F, 0x1A7F )
+        , ( 0x1AB0, 0x1ACE ), ( 0x1B6B, 0x1B73 ), ( 0x1DC0, 0x1DFF )
+        , ( 0x20D0, 0x20F0 ), ( 0x2CEF, 0x2CF1 ), ( 0x2DE0, 0x2DFF )
+        , ( 0x3099, 0x309A ), ( 0xA66F, 0xA672 ), ( 0xA674, 0xA67D )
+        , ( 0xA69E, 0xA69F ), ( 0xA6F0, 0xA6F1 ), ( 0xA8E0, 0xA8F1 )
+        , ( 0xFE20, 0xFE2F ), ( 0x101FD, 0x101FD ), ( 0x10376, 0x1037A )
+        , ( 0x10EAB, 0x10EAC ), ( 0x10F46, 0x10F50 ), ( 0x10F82, 0x10F85 )
+        , ( 0x11300, 0x11301 ), ( 0x1133B, 0x1133C ), ( 0x11366, 0x1136C )
+        , ( 0x11370, 0x11374 ), ( 0x16AF0, 0x16AF4 ), ( 0x1CF00, 0x1CF2D )
+        , ( 0x1CF30, 0x1CF46 ), ( 0x1D165, 0x1D169 ), ( 0x1D16D, 0x1D172 )
+        , ( 0x1D17B, 0x1D182 ), ( 0x1D185, 0x1D18B ), ( 0x1D1AA, 0x1D1AD )
+        , ( 0x1D242, 0x1D244 ), ( 0x1E000, 0x1E006 ), ( 0x1E008, 0x1E018 )
+        , ( 0x1E01B, 0x1E021 ), ( 0x1E023, 0x1E024 ), ( 0x1E026, 0x1E02A )
+        , ( 0x1E08F, 0x1E08F ), ( 0x1E8D0, 0x1E8D6 )
+        ]
+
+
+{-| Binary search to check if character is combining (zero-width).
+-}
+isCombining : Int -> Bool
+isCombining ucs =
+    let
+        maxIdx =
+            Array.length combiningRanges - 1
+    in
+    case ( Array.get 0 combiningRanges, Array.get maxIdx combiningRanges ) of
+        ( Just ( firstStart, _ ), Just ( _, lastEnd ) ) ->
+            if ucs < firstStart || ucs > lastEnd then
+                False
+
+            else
+                bisearchCombining ucs 0 maxIdx
+
+        _ ->
+            False
+
+
+bisearchCombining : Int -> Int -> Int -> Bool
+bisearchCombining ucs min max =
+    if max < min then
+        False
+
+    else
+        let
+            mid =
+                (min + max) // 2
+        in
+        case Array.get mid combiningRanges of
+            Nothing ->
+                False
+
+            Just ( rangeStart, rangeEnd ) ->
+                if ucs > rangeEnd then
+                    bisearchCombining ucs (mid + 1) max
+
+                else if ucs < rangeStart then
+                    bisearchCombining ucs min (mid - 1)
+
+                else
+                    True
+
+
+{-| Doublewidth character ranges (2 columns) from Go runewidth package.
+Includes CJK, emoji, and fullwidth characters.
+-}
+doublewidthRanges : Array ( Int, Int )
+doublewidthRanges =
+    Array.fromList
+        [ ( 0x1100, 0x115F ), ( 0x231A, 0x231B ), ( 0x2329, 0x232A )
+        , ( 0x23E9, 0x23EC ), ( 0x23F0, 0x23F0 ), ( 0x23F3, 0x23F3 )
+        , ( 0x25FD, 0x25FE ), ( 0x2614, 0x2615 ), ( 0x2648, 0x2653 )
+        , ( 0x267F, 0x267F ), ( 0x2693, 0x2693 ), ( 0x26A1, 0x26A1 )
+        , ( 0x26AA, 0x26AB ), ( 0x26BD, 0x26BE ), ( 0x26C4, 0x26C5 )
+        , ( 0x26CE, 0x26CE ), ( 0x26D4, 0x26D4 ), ( 0x26EA, 0x26EA )
+        , ( 0x26F2, 0x26F3 ), ( 0x26F5, 0x26F5 ), ( 0x26FA, 0x26FA )
+        , ( 0x26FD, 0x26FD ), ( 0x2705, 0x2705 ), ( 0x270A, 0x270B )
+        , ( 0x2728, 0x2728 ), ( 0x274C, 0x274C ), ( 0x274E, 0x274E )
+        , ( 0x2753, 0x2755 ), ( 0x2757, 0x2757 ), ( 0x2795, 0x2797 )
+        , ( 0x27B0, 0x27B0 ), ( 0x27BF, 0x27BF ), ( 0x2B1B, 0x2B1C )
+        , ( 0x2B50, 0x2B50 ), ( 0x2B55, 0x2B55 ), ( 0x2E80, 0x2E99 )
+        , ( 0x2E9B, 0x2EF3 ), ( 0x2F00, 0x2FD5 ), ( 0x2FF0, 0x303E )
+        , ( 0x3041, 0x3096 ), ( 0x3099, 0x30FF ), ( 0x3105, 0x312F )
+        , ( 0x3131, 0x318E ), ( 0x3190, 0x31E3 ), ( 0x31EF, 0x321E )
+        , ( 0x3220, 0x3247 ), ( 0x3250, 0x4DBF ), ( 0x4E00, 0xA48C )
+        , ( 0xA490, 0xA4C6 ), ( 0xA960, 0xA97C ), ( 0xAC00, 0xD7A3 )
+        , ( 0xF900, 0xFAFF ), ( 0xFE10, 0xFE19 ), ( 0xFE30, 0xFE52 )
+        , ( 0xFE54, 0xFE66 ), ( 0xFE68, 0xFE6B ), ( 0xFF01, 0xFF60 )
+        , ( 0xFFE0, 0xFFE6 ), ( 0x16FE0, 0x16FE4 ), ( 0x16FF0, 0x16FF1 )
+        , ( 0x17000, 0x187F7 ), ( 0x18800, 0x18CD5 ), ( 0x18D00, 0x18D08 )
+        , ( 0x1AFF0, 0x1AFF3 ), ( 0x1AFF5, 0x1AFFB ), ( 0x1AFFD, 0x1AFFE )
+        , ( 0x1B000, 0x1B122 ), ( 0x1B132, 0x1B132 ), ( 0x1B150, 0x1B152 )
+        , ( 0x1B155, 0x1B155 ), ( 0x1B164, 0x1B167 ), ( 0x1B170, 0x1B2FB )
+        , ( 0x1F004, 0x1F004 ), ( 0x1F0CF, 0x1F0CF ), ( 0x1F18E, 0x1F18E )
+        , ( 0x1F191, 0x1F19A ), ( 0x1F200, 0x1F202 ), ( 0x1F210, 0x1F23B )
+        , ( 0x1F240, 0x1F248 ), ( 0x1F250, 0x1F251 ), ( 0x1F260, 0x1F265 )
+        , ( 0x1F300, 0x1F320 ), ( 0x1F32D, 0x1F335 ), ( 0x1F337, 0x1F37C )
+        , ( 0x1F37E, 0x1F393 ), ( 0x1F3A0, 0x1F3CA ), ( 0x1F3CF, 0x1F3D3 )
+        , ( 0x1F3E0, 0x1F3F0 ), ( 0x1F3F4, 0x1F3F4 ), ( 0x1F3F8, 0x1F43E )
+        , ( 0x1F440, 0x1F440 ), ( 0x1F442, 0x1F4FC ), ( 0x1F4FF, 0x1F53D )
+        , ( 0x1F54B, 0x1F54E ), ( 0x1F550, 0x1F567 ), ( 0x1F57A, 0x1F57A )
+        , ( 0x1F595, 0x1F596 ), ( 0x1F5A4, 0x1F5A4 ), ( 0x1F5FB, 0x1F64F )
+        , ( 0x1F680, 0x1F6C5 ), ( 0x1F6CC, 0x1F6CC ), ( 0x1F6D0, 0x1F6D2 )
+        , ( 0x1F6D5, 0x1F6D7 ), ( 0x1F6DC, 0x1F6DF ), ( 0x1F6EB, 0x1F6EC )
+        , ( 0x1F6F4, 0x1F6FC ), ( 0x1F7E0, 0x1F7EB ), ( 0x1F7F0, 0x1F7F0 )
+        , ( 0x1F90C, 0x1F93A ), ( 0x1F93C, 0x1F945 ), ( 0x1F947, 0x1F9FF )
+        , ( 0x1FA70, 0x1FA7C ), ( 0x1FA80, 0x1FA88 ), ( 0x1FA90, 0x1FABD )
+        , ( 0x1FABF, 0x1FAC5 ), ( 0x1FACE, 0x1FADB ), ( 0x1FAE0, 0x1FAE8 )
+        , ( 0x1FAF0, 0x1FAF8 ), ( 0x20000, 0x2FFFD ), ( 0x30000, 0x3FFFD )
+        ]
+
+
+{-| Check if character is in doublewidth table (2 columns).
+Uses binary search for O(log n) performance.
+-}
+isDoublewidth : Int -> Bool
+isDoublewidth ucs =
+    let
+        maxIdx =
+            Array.length doublewidthRanges - 1
+    in
+    case ( Array.get 0 doublewidthRanges, Array.get maxIdx doublewidthRanges ) of
+        ( Just ( firstStart, _ ), Just ( _, lastEnd ) ) ->
+            if ucs < firstStart || ucs > lastEnd then
+                False
+
+            else
+                bisearchDoublewidth ucs 0 maxIdx
+
+        _ ->
+            False
+
+
+bisearchDoublewidth : Int -> Int -> Int -> Bool
+bisearchDoublewidth ucs min max =
+    if max < min then
+        False
+
+    else
+        let
+            mid =
+                (min + max) // 2
+        in
+        case Array.get mid doublewidthRanges of
+            Nothing ->
+                False
+
+            Just ( rangeStart, rangeEnd ) ->
+                if ucs > rangeEnd then
+                    bisearchDoublewidth ucs (mid + 1) max
+
+                else if ucs < rangeStart then
+                    bisearchDoublewidth ucs min (mid - 1)
+
+                else
+                    True
+
+
+{-| Check if character is a zero-width format/nonprint character.
+Based on Go runewidth's nonprint table - these have no visual width.
+Includes control chars, format chars (ZWSP, ZWJ, etc), surrogates, and special markers.
+-}
+isZeroWidthFormat : Int -> Bool
+isZeroWidthFormat ucs =
+    -- Soft hyphen (already handled in control char range but mentioned in Go nonprint)
+    ucs == 0x00AD
+    -- Arabic format character
+    || ucs == 0x070F
+    -- Mongolian vowel separator range
+    || (ucs >= 0x180B && ucs <= 0x180E)
+    -- Zero-width space, ZWNJ, ZWJ, LRM, RLM, and related format characters
+    || (ucs >= 0x200B && ucs <= 0x200F)
+    -- Line/paragraph separators and bidi formatting
+    || (ucs >= 0x2028 && ucs <= 0x202E)
+    -- Inhibit/activate controls
+    || (ucs >= 0x206A && ucs <= 0x206F)
+    -- Zero-width no-break space (BOM)
+    || ucs == 0xFEFF
+    -- Interlinear annotation chars
+    || (ucs >= 0xFFF9 && ucs <= 0xFFFB)
+    -- Noncharacters
+    || ucs == 0xFFFE
+    || ucs == 0xFFFF
+
+
+{-| Calculate display width of a character.
+Returns 0 for null/control/combining/format, 2 for wide, 1 for normal.
+-}
+charDisplayWidth : Char -> Int
+charDisplayWidth char =
+    let
+        ucs =
+            Char.toCode char
+    in
+    if ucs < 0x0300 then
+        -- Fast path for ASCII/Latin
+        if ucs == 0 then 0
+        else if ucs < 32 || (ucs >= 0x7F && ucs < 0xA0) || ucs == 0x00AD then 0
+        else 1
+
+    else if isDoublewidth ucs then
+        2
+
+    else if isCombining ucs then
+        0
+
+    else if isZeroWidthFormat ucs then
+        0
+
+    else
+        1
+
+
+{-| Calculate display width of a string (terminal columns).
+-}
+stringDisplayWidth : String -> Int
+stringDisplayWidth str =
+    if String.isEmpty str then
+        0
+    else
+        String.foldl (\char acc -> acc + charDisplayWidth char) 0 str
+
+
 chunkLen : Chunk -> Int
 chunkLen =
-    String.length << .text
+    stringDisplayWidth << .text
 
 
 writeChunk : Int -> Chunk -> Line -> Line

--- a/tests/AnsiLogBenchmark.elm
+++ b/tests/AnsiLogBenchmark.elm
@@ -1,0 +1,192 @@
+module AnsiLogBenchmark exposing (main)
+
+{-| Realistic benchmark suite for Ansi.Log performance testing.
+
+Focuses on real-world scenarios with actual build log data patterns.
+
+-}
+
+import Ansi
+import Ansi.Log as Log
+import Benchmark exposing (Benchmark, benchmark, describe)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+
+
+main : BenchmarkProgram
+main =
+    program suite
+
+
+suite : Benchmark
+suite =
+    describe "Ansi.Log Real-World Performance"
+        [ typicalBuildLogBenchmark
+        , largeOutputBenchmark
+        , colorIntensiveBenchmark
+        , progressBarBenchmark
+        , unicodeMixedBenchmark
+        , streamingUpdatesBenchmark
+        ]
+
+
+{-| Realistic build log with typical compiler output patterns
+-}
+buildLogData : String
+buildLogData =
+    String.concat
+        [ "\u{001B}[32m[1/12]\u{001B}[0m Compiling src/Main.elm\n"
+        , "\u{001B}[33mWarning:\u{001B}[0m Unused import in line 45\n"
+        , "  \u{001B}[2m|\u{001B}[0m\n"
+        , "45| import Dict exposing (Dict)\n"
+        , "  \u{001B}[2m|\u{001B}[0m        \u{001B}[31m^^^^\u{001B}[0m\n"
+        , "\u{001B}[32m[2/12]\u{001B}[0m Compiling src/Utils.elm\n"
+        , "\u{001B}[32m[3/12]\u{001B}[0m Compiling src/Types.elm\n"
+        , "\u{001B}[32m✓\u{001B}[0m Compilation successful\n"
+        , "\u{001B}[36mBuild time: 2.34s\u{001B}[0m\n"
+        , "Sending build context to Docker daemon  15.36MB\r\n"
+        , "Step 1/8 : FROM node:18-alpine\n"
+        , " ---> \u{001B}[32mUsing cache\u{001B}[0m\n"
+        , " ---> a1b2c3d4e5f6\n"
+        , "Step 2/8 : WORKDIR /app\n"
+        , " ---> \u{001B}[32mUsing cache\u{001B}[0m\n"
+        , "added 234 packages in 12s\n"
+        , "\u{001B}[32mSuccessfully built e5f6a1b2c3d4\u{001B}[0m\n"
+        ]
+
+
+{-| Test runner output with pass/fail indicators
+-}
+testRunnerLog : String
+testRunnerLog =
+    String.concat
+        [ "\u{001B}[1mRunning tests...\u{001B}[0m\n\n"
+        , "  \u{001B}[32m✓\u{001B}[0m should parse basic ANSI codes\n"
+        , "  \u{001B}[32m✓\u{001B}[0m should handle colors correctly\n"
+        , "  \u{001B}[31m✗\u{001B}[0m should handle cursor movements\n"
+        , "    \u{001B}[2mExpected:\u{001B}[0m { row: 5, col: 10 }\n"
+        , "    \u{001B}[2mReceived:\u{001B}[0m { row: 5, col: 9 }\n"
+        , "  \u{001B}[32m✓\u{001B}[0m should merge consecutive chunks\n"
+        , "  \u{001B}[33m○\u{001B}[0m should render unicode (skipped)\n\n"
+        , "\u{001B}[32m4 passed\u{001B}[0m, \u{001B}[31m1 failed\u{001B}[0m, \u{001B}[33m1 skipped\u{001B}[0m\n"
+        ]
+
+
+{-| Benchmark 1: Typical build log output
+Most common real-world use case
+-}
+typicalBuildLogBenchmark : Benchmark
+typicalBuildLogBenchmark =
+    benchmark "typical build log (compiler + docker + tests)" <|
+        \_ ->
+            Log.update (buildLogData ++ testRunnerLog) (Log.init Log.Cooked)
+
+
+{-| Benchmark 2: Large output (100 lines)
+Tests performance with substantial logs
+-}
+largeOutputBenchmark : Benchmark
+largeOutputBenchmark =
+    let
+        largeLog = String.repeat 10 (buildLogData ++ testRunnerLog)
+    in
+    benchmark "large output (100 lines)" <|
+        \_ ->
+            Log.update largeLog (Log.init Log.Cooked)
+
+
+{-| Benchmark 3: Color-intensive output
+Heavy SGR code parsing with RGB colors
+-}
+colorIntensiveBenchmark : Benchmark
+colorIntensiveBenchmark =
+    let
+        rgbColors =
+            String.concat
+                [ "\u{001B}[38;2;255;100;50mOrange\u{001B}[0m "
+                , "\u{001B}[38;2;50;150;255mBlue\u{001B}[0m "
+                , "\u{001B}[1;3;4;31mBold Italic Underline\u{001B}[0m "
+                , "\u{001B}[38;5;196mBright Red\u{001B}[0m\n"
+                ]
+        coloredOutput = String.repeat 10 (testRunnerLog ++ rgbColors)
+    in
+    benchmark "color-intensive (RGB + styles)" <|
+        \_ ->
+            Log.update coloredOutput (Log.init Log.Cooked)
+
+
+{-| Benchmark 4: Progress bars with carriage returns
+In-place updates common in CLI tools
+-}
+progressBarBenchmark : Benchmark
+progressBarBenchmark =
+    let
+        progressBar =
+            String.concat
+                [ "Downloading: [          ] 0%\r"
+                , "Downloading: [##        ] 20%\r"
+                , "Downloading: [####      ] 40%\r"
+                , "Downloading: [######    ] 60%\r"
+                , "Downloading: [########  ] 80%\r"
+                , "Downloading: [##########] 100%\n"
+                , "Loading |  \r"
+                , "Loading /  \r"
+                , "Loading -  \r"
+                , "Loading \\  \r"
+                , "Done!\n"
+                ]
+        repeated = String.repeat 5 progressBar
+    in
+    benchmark "progress bars (carriage returns)" <|
+        \_ ->
+            Log.update repeated (Log.init Log.Cooked)
+
+
+{-| Benchmark 5: Unicode with emoji and CJK
+Wide character width calculations
+-}
+unicodeMixedBenchmark : Benchmark
+unicodeMixedBenchmark =
+    let
+        unicodeLog =
+            String.concat
+                [ "\u{001B}[32m✓ 编译成功\u{001B}[0m Build successful 🎉\n"
+                , "构建时间: 3.21秒 Time: 3.21s\n"
+                , "こんにちは 안녕하세요 Hello 世界 🚀💻🔥\n"
+                , "\u{001B}[33mcommit a1b2c3d\u{001B}[0m ✨ Add feature\n"
+                ]
+        mixed = String.repeat 10 unicodeLog
+    in
+    benchmark "unicode mixed (emoji + CJK + ASCII)" <|
+        \_ ->
+            Log.update mixed (Log.init Log.Cooked)
+
+
+{-| Benchmark 6: Incremental streaming
+Realistic chunked updates with split ANSI codes
+-}
+streamingUpdatesBenchmark : Benchmark
+streamingUpdatesBenchmark =
+    let
+        -- Simulate realistic streaming where ANSI codes are split
+        chunks =
+            [ "\u{001B}[32m[1"
+            , "/12]\u{001B}[0m Comp"
+            , "iling src/Ma"
+            , "in.elm\n\u{001B}[33mWarn"
+            , "ing:\u{001B}[0m Unu"
+            , "sed import\n"
+            , "\u{001B}[32m[2/12]"
+            , "\u{001B}[0m Compili"
+            , "ng src/Utils.elm\n"
+            , "\u{001B}[32m✓\u{001B}[0m Done\n"
+            , "\u{001B}[2K\u{001B}[1G"
+            , "fetching... [", "1/4", "]\r"
+            , "\u{001B}[2K\u{001B}[1G"
+            , "Done\n"
+            ]
+        -- Repeat to make benchmark meaningful
+        allChunks = List.concat (List.repeat 3 chunks)
+    in
+    benchmark "incremental streaming (42 chunks)" <|
+        \_ ->
+            List.foldl Log.update (Log.init Log.Cooked) allChunks

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,4 +1,4 @@
-module Tests exposing (all, assertWindowRendersAs, colorCode, esc, log, parsing, renderChunk, renderLine, renderWindow, styleFlags)
+module Tests exposing (all, assertWindowRendersAs, colorCode, displayWidthTests, esc, log, parsing, renderChunk, renderLine, renderWindow, styleFlags)
 
 import Ansi
 import Ansi.Log
@@ -11,7 +11,7 @@ import Test exposing (..)
 
 all : Test
 all =
-    describe "ANSI" [ parsing, log, hyperlinkTests ]
+    describe "ANSI" [ parsing, log, hyperlinkTests, displayWidthTests ]
 
 
 parsing : Test
@@ -795,4 +795,290 @@ log =
                     , "onetwo\u{001B}[3D\u{001B}[1KTWO\u{000D}\n"
                     , "onetwo\u{001B}[2KTHREEFOUR\u{000D}\n"
                     ]
+        ]
+
+
+displayWidthTests : Test
+displayWidthTests =
+    describe "Display Width Calculation"
+        [ describe "Basic ASCII"
+            [ test "ASCII characters are 1 column" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "Hello" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 5 width
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Numbers are 1 column each" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "12345" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 5 width
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
+        , describe "Emoji (2 columns)"
+            [ test "Coffee emoji ☕ is 2 columns" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "☕" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 2 width
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Rocket emoji 🚀 is 2 columns" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "🚀" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 2 width
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Multiple emoji" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "☕🚀🎉" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 6 width  -- 2 + 2 + 2
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Emoji mixed with ASCII" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "Hi ☕ there" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 11 width  -- 3 + 2 + 6
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
+        , describe "CJK Characters (2 columns)"
+            [ test "Chinese characters are 2 columns each" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "你好" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 4 width  -- 2 + 2
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Japanese Hiragana are 2 columns each" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "こんにちは" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 10 width  -- 5 chars × 2 columns
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Korean Hangul syllables are 2 columns each" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "한글" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 4 width  -- 2 + 2
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
+        , describe "Fullwidth Forms (2 columns)"
+            [ test "Fullwidth ASCII letter is 2 columns" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "Ａ" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 2 width
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Fullwidth number is 2 columns" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "１２３" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 6 width  -- 3 chars × 2 columns
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
+        , describe "Combining Characters (0 columns)"
+            [ test "Combining accent e + ́ displays as 1 column" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        -- é as combining: e (U+0065) + combining acute (U+0301)
+                        updated = Ansi.Log.update "e\u{0301}" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 1 width  -- e=1, combining=0
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "café with combining accent" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        -- café: c + a + f + e + combining-acute
+                        updated = Ansi.Log.update "cafe\u{0301}" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 4 width  -- c=1, a=1, f=1, e=1, combining=0
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
+        , describe "Zero-Width Characters"
+            [ test "Zero-width space is 0 columns" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "a\u{200B}b" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 2 width  -- a=1, zero-width=0, b=1
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Zero-width joiner is 0 columns" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "a\u{200D}b" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 2 width  -- a=1, ZWJ=0, b=1
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
+        , describe "Control Characters (0 columns)"
+            [ test "NULL character is 0 columns" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "a\u{0000}b" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 2 width  -- a=1, NULL=0, b=1
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
+        , describe "Mixed Content"
+            [ test "ASCII + emoji + CJK" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "Hi ☕ 你好" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 10 width  -- H=1, i=1, space=1, ☕=2, space=1, 你=2, 好=2
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Real-world example: Rich box message" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "Even the price of a ☕ can brighten my day!" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 43 width  -- 41 ASCII + 2 for emoji
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Complex mix with combining chars" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        -- "café ☕ 你好" with combining é
+                        updated = Ansi.Log.update "cafe\u{0301} ☕ 你好" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 12 width  -- cafe=4, combining=0, space=1, ☕=2, space=1, 你好=4
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
+        , describe "Edge Cases"
+            [ test "Empty string" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "" model
+                    in
+                    Expect.equal 0 (Array.length updated.lines)
+            , test "Only spaces" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "     " model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 5 width
+                        Nothing ->
+                            Expect.fail "No line created"
+            , test "Only emoji" <|
+                \() ->
+                    let
+                        model = Ansi.Log.init Ansi.Log.Raw
+                        updated = Ansi.Log.update "🎉🎉🎉" model
+                        line = Array.get 0 updated.lines
+                    in
+                    case line of
+                        Just (_, width) ->
+                            Expect.equal 6 width  -- 3 emoji × 2 columns
+                        Nothing ->
+                            Expect.fail "No line created"
+            ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -139,7 +139,7 @@ parsing =
                     [ Ansi.CursorUp 5
                     , Ansi.CursorDown 1
                     , Ansi.CursorForward 50
-                    , Ansi.CursorBack 1
+                    , Ansi.CursorBackward 1
                     , Ansi.CursorPosition 1 50
                     , Ansi.CursorPosition 50 1
                     ]


### PR DESCRIPTION
Implement proper width calculation for CJK (2 cols), emoji (2 cols), combining marks (0 cols), and zero-width chars using binary search over Unicode ranges. Includes comprehensive test suite.