### PR TITLE
Align elm-ansi with ECMA-35/ECMA-48 spec and add comprehensive control code tests

### DIFF
--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -184,7 +184,7 @@ parseChar c parser =
     case parser of
         Parser (Unescaped str) hasLink model update ->
             case c of
-                '\u{000D}' ->
+                '\r' ->
                     let
                         updatedModel = if str == "" then model else update (Print str) model
                     in
@@ -196,7 +196,7 @@ parseChar c parser =
                     in
                     Parser (Unescaped "") hasLink (update Linebreak updatedModel) update
 
-                '\u{001B}' ->
+                '\u{001B}' -> -- ESC
                     let
                         updatedModel = if str == "" then model else update (Print str) model
                     in
@@ -260,14 +260,13 @@ parseChar c parser =
 
         Parser (OSC chars) hasLink model update ->
             case c of
-                '\u{0007}' ->
-                    -- BEL character marks the end of an OSC sequence
+                '\u{0007}' -> -- BEL marks the end of an OSC sequence
                     let
                         (actions, newHasLink) = parseOSCSequence hasLink chars
                     in
                     completeEscapeSequence parser newHasLink actions
 
-                '\u{001B}' ->
+                '\u{001B}' -> -- ESC
                     -- Possibly the start of an ESC+backslash terminator
                     Parser (OSCAwaitingTerminator chars) hasLink model update
 

--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -426,6 +426,33 @@ parseChar c parser =
                 '+' ->
                     Parser CharsetDesignation hasLink model update
 
+                '7' ->
+                    Parser (Unescaped "") hasLink (update SaveCursorPosition model) update
+
+                '8' ->
+                    Parser (Unescaped "") hasLink (update RestoreCursorPosition model) update
+
+                'M' ->
+                    Parser (Unescaped "") hasLink (update (CursorUp 1) model) update
+
+                'D' ->
+                    Parser (Unescaped "") hasLink (update (CursorDown 1) model) update
+
+                'E' ->
+                    Parser (Unescaped "") hasLink (update Linebreak (update CarriageReturn model)) update
+
+                '=' ->
+                    Parser (Unescaped "") hasLink model update
+
+                '>' ->
+                    Parser (Unescaped "") hasLink model update
+
+                'c' ->
+                    Parser (Unescaped "") hasLink model update
+
+                'H' ->
+                    Parser (Unescaped "") hasLink model update
+
                 '\\' ->
                     Parser (Unescaped "\\") hasLink model update
 

--- a/src/Ansi.elm
+++ b/src/Ansi.elm
@@ -82,8 +82,6 @@ type Color
     | Custom Int Int Int
 
 
-{-| Method to erase the display or line.
--}
 type EraseMode
     = EraseToBeginning
     | EraseToEnd
@@ -117,11 +115,6 @@ type ParameterMarker
     | Question      -- ? (0x3F)
 
 
-emptyParser : a -> (Action -> a -> a) -> Parser a
-emptyParser model update =
-    Parser (Unescaped "") False model update
-
-
 {-| Convert an arbitrary String of text into a sequence of actions.
 
 If the input string ends with a partial ANSI escape sequence, it will be
@@ -138,13 +131,18 @@ parse =
 -}
 parseInto : a -> (Action -> a -> a) -> String -> a
 parseInto model update ansi =
-    completeParsing <|
-        List.foldl parseChar (emptyParser model update) <|
+    finalizeParsing <|
+        List.foldl parseChar (initialParser model update) <|
             String.toList ansi
 
 
-completeParsing : Parser a -> a
-completeParsing parser =
+initialParser : a -> (Action -> a -> a) -> Parser a
+initialParser model update =
+    Parser (Unescaped "") False model update
+
+
+finalizeParsing : Parser a -> a
+finalizeParsing parser =
     case parser of
         Parser Escaped _ model update ->
             update (Remainder "\u{001B}") model
@@ -158,7 +156,7 @@ completeParsing parser =
                     Just Question -> "?"
                     Nothing -> ""
             in
-            update (Remainder <| "\u{001B}[" ++ markerStr ++ encodeCodes (parsedCodes ++ [ currentCode ])) model
+            update (Remainder <| "\u{001B}[" ++ markerStr ++ formatCodes (parsedCodes ++ [ currentCode ])) model
 
         Parser (OSC chars) _ model update ->
             update (Remainder <| "\u{001B}]" ++ chars) model
@@ -176,224 +174,9 @@ completeParsing parser =
             update (Print str) model
 
 
-encodeCodes : List (Maybe Int) -> String
-encodeCodes codes =
-    String.join ";" (List.map encodeCode codes)
-
-
-encodeCode : Maybe Int -> String
-encodeCode code =
-    case code of
-        Nothing ->
-            ""
-
-        Just num ->
-            String.fromInt num
-
-
-{-| Converts a color code to an 8-bit color per
-<https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit>
--}
-colorCode : Int -> Maybe Color
-colorCode code =
-    case code of
-        0 -> Just Black
-        1 -> Just Red
-        2 -> Just Green
-        3 -> Just Yellow
-        4 -> Just Blue
-        5 -> Just Magenta
-        6 -> Just Cyan
-        7 -> Just White
-        8 -> Just BrightBlack
-        9 -> Just BrightRed
-        10 -> Just BrightGreen
-        11 -> Just BrightYellow
-        12 -> Just BrightBlue
-        13 -> Just BrightMagenta
-        14 -> Just BrightCyan
-        15 -> Just BrightWhite
-
-        _ ->
-            if code < 232 then
-                -- 6x6x6 RGB cube (codes 16-231, 216 colors)
-                let
-                    c = code - 16
-                    b = modBy 6 c
-                    g = modBy 6 (c // 6)
-                    r = c // 36  -- Division by 36 (6²) extracts red component
-                in
-                Just <| Custom (scale6 r) (scale6 g) (scale6 b)
-
-            else if code < 256 then
-                -- Grayscale ramp (codes 232-255, 24 shades)
-                let
-                    gray = (code - 232) * 10 + 8
-                in
-                Just <| Custom gray gray gray
-
-            else
-                Nothing
-
-
-{-| Scales [0,5] -> [0,255] (non-uniformly)
-0 -> 0, 1 -> 95, 2 -> 135, 3 -> 175, 4 -> 215, 5 -> 255
--}
-scale6 : Int -> Int
-scale6 n =
-    if n == 0 then 0 else 55 + n * 40
-
-
-{-| Capture SGR arguments in pattern match
--}
-captureArguments : List Int -> List Action
-captureArguments list =
-    case list of
-        -- Incomplete 256-color sequences - skip them entirely
-        38 :: 5 :: [] ->
-            []
-
-        48 :: 5 :: [] ->
-            []
-
-        -- Incomplete 24-bit color sequences - skip them entirely
-        38 :: 2 :: _ :: [] ->
-            []
-
-        38 :: 2 :: _ :: _ :: [] ->
-            []
-
-        48 :: 2 :: _ :: [] ->
-            []
-
-        48 :: 2 :: _ :: _ :: [] ->
-            []
-
-        -- Valid 256-color sequences - only emit action if colorCode succeeds
-        38 :: 5 :: n :: xs ->
-            case colorCode n of
-                Just color ->
-                    SetForeground (Just color) :: captureArguments xs
-                Nothing ->
-                    captureArguments xs
-
-        48 :: 5 :: n :: xs ->
-            case colorCode n of
-                Just color ->
-                    SetBackground (Just color) :: captureArguments xs
-                Nothing ->
-                    captureArguments xs
-
-        -- Valid 24-bit color sequences
-        38 :: 2 :: r :: g :: b :: xs ->
-            let
-                c =
-                    clamp 0 255
-            in
-            SetForeground (Just <| Custom (c r) (c g) (c b)) :: captureArguments xs
-
-        48 :: 2 :: r :: g :: b :: xs ->
-            let
-                c =
-                    clamp 0 255
-            in
-            SetBackground (Just <| Custom (c r) (c g) (c b)) :: captureArguments xs
-
-        n :: xs ->
-            codeActions n ++ captureArguments xs
-
-        [] ->
-            []
-
-
--- Check if a character is an unreserved character according to RFC 3986
-isUnreservedChar : Char -> Bool
-isUnreservedChar c =
-    Char.isAlphaNum c || c == '-' || c == '.' || c == '_' || c == '~'
-
-
--- Check if a character is a reserved character according to RFC 3986
-isReservedChar : Char -> Bool
-isReservedChar c =
-    String.contains (String.fromChar c) ":/?#[]@!$&'()*+,;="
-
-
--- Validate that a parameter follows HTTP spec but doesn't contain the
--- hyperlink protocol delimiters
-validateSingleParam : String -> Bool
-validateSingleParam param =
-    -- For hyperlink parameters, we need to exclude : and ; as they're delimiters
-    -- in the hyperlink protocol, even though they're valid in HTTP URLs
-    String.all (\c ->
-        (isUnreservedChar c || (isReservedChar c && c /= ':' && c /= ';')) &&
-        Char.toCode c >= 32 && Char.toCode c <= 126
-    ) param
-
-
-processHyperlinkParts : String -> String -> List Action
-processHyperlinkParts params uri =
-    let
-        parsedParams = parseParams params
-        validParams = List.all validateSingleParam parsedParams
-
-        processedUri =
-            if String.any (\c -> Char.toCode c > 127) uri then
-                String.toList uri
-                    |> List.map (\c ->
-                        if Char.toCode c > 127 then
-                            Url.percentEncode (String.fromChar c)
-                        else
-                            String.fromChar c
-                    )
-                    |> String.concat
-            else
-                uri
-    in
-    if not validParams then
-        []
-    else
-        [HyperlinkStart parsedParams processedUri]
-
-
-parseOSCWithState : Bool -> String -> (List Action, Bool)
-parseOSCWithState hasActiveLink str =
-    -- Specifically check for the hyperlink end sequence "8;;"
-    if str == "8;;" then
-        if hasActiveLink then
-            ([HyperlinkEnd], False)
-        else
-            ([], False)
-    -- Check for hyperlink start sequence "8;params;uri"
-    else if String.startsWith "8;" str then
-        -- Split only on first 2 semicolons to preserve semicolons in URI
-        case String.split ";" str of
-            "8" :: params :: rest ->
-                -- URI might contain semicolons, so rejoin remaining parts
-                let
-                    uri = String.join ";" rest
-                in
-                if String.isEmpty uri then
-                    -- Invalid format: no URI provided
-                    ([], hasActiveLink)
-                else
-                    let
-                        actions = processHyperlinkParts params uri
-                    in
-                    (actions, not (List.isEmpty actions))
-            _ ->
-                ([], hasActiveLink)
-    else
-        ([], hasActiveLink)
-
-
-{-| Parse hyperlink parameters
--}
-parseParams : String -> List String
-parseParams params =
-    if String.isEmpty params then
-        []
-    else
-        String.split ":" params
+completeEscapeSequence : Parser a -> Bool -> List Action -> Parser a
+completeEscapeSequence (Parser _ hasLink model update) newHasLink actions =
+    Parser (Unescaped "") newHasLink (List.foldl update model actions) update
 
 
 parseChar : Char -> Parser a -> Parser a
@@ -480,9 +263,9 @@ parseChar c parser =
                 '\u{0007}' ->
                     -- BEL character marks the end of an OSC sequence
                     let
-                        (actions, newHasLink) = parseOSCWithState hasLink chars
+                        (actions, newHasLink) = parseOSCSequence hasLink chars
                     in
-                    finishEscapeSequence parser newHasLink actions
+                    completeEscapeSequence parser newHasLink actions
 
                 '\u{001B}' ->
                     -- Possibly the start of an ESC+backslash terminator
@@ -497,9 +280,9 @@ parseChar c parser =
                 '\\' ->
                     -- ESC+backslash terminator found
                     let
-                        (actions, newHasLink) = parseOSCWithState hasLink chars
+                        (actions, newHasLink) = parseOSCSequence hasLink chars
                     in
-                    finishEscapeSequence parser newHasLink actions
+                    completeEscapeSequence parser newHasLink actions
 
                 _ ->
                     -- Not a terminator, continue as a normal OSC sequence with ESC included
@@ -525,22 +308,23 @@ parseChar c parser =
 
                     _ ->
                         -- Not a parameter marker, process as normal CSI character
-                        handleCSICommand c marker parsedCodes currentCode hasLink model update parser
+                        parseCSICommand c marker parsedCodes currentCode hasLink model update parser
             else
                 -- We already have a marker or codes, process normally
-                handleCSICommand c marker parsedCodes currentCode hasLink model update parser
+                parseCSICommand c marker parsedCodes currentCode hasLink model update parser
 
 
 -- Helper function to handle CSI command characters
-handleCSICommand : Char -> Maybe ParameterMarker -> List (Maybe Int) -> Maybe Int -> Bool -> a -> (Action -> a -> a) -> Parser a -> Parser a
-handleCSICommand c marker parsedCodes currentCode hasLink model update parser =
+
+parseCSICommand : Char -> Maybe ParameterMarker -> List (Maybe Int) -> Maybe Int -> Bool -> a -> (Action -> a -> a) -> Parser a -> Parser a
+parseCSICommand c marker parsedCodes currentCode hasLink model update parser =
     -- If we have a parameter marker (<>=?), this is a private/experimental sequence
     -- We consume it but don't execute any actions (per ANSI/DEC VT100 standard)
     case marker of
         Just _ ->
             -- Any letter terminates the sequence, but we produce no actions
             if Char.isAlpha c then
-                finishEscapeSequence parser hasLink []
+                completeEscapeSequence parser hasLink []
             else if c == ';' then
                 Parser (CSI { marker = marker, parsedCodes = parsedCodes ++ [ currentCode ], currentCode = Nothing }) hasLink model update
             else if Char.isDigit c then
@@ -553,65 +337,65 @@ handleCSICommand c marker parsedCodes currentCode hasLink model update parser =
                 Parser (CSI { marker = marker, parsedCodes = parsedCodes, currentCode = Just newCode }) hasLink model update
             else
                 -- Unknown character in private sequence, discard
-                finishEscapeSequence parser hasLink []
+                completeEscapeSequence parser hasLink []
 
         Nothing ->
             -- No marker means standard CSI sequence, process normally
             case c of
                 'm' ->
-                    finishEscapeSequence parser hasLink <|
-                        captureArguments <|
+                    completeEscapeSequence parser hasLink <|
+                        processSGRCodes <|
                             List.map (Maybe.withDefault 0) (parsedCodes ++ [ currentCode ])
 
                 'A' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ CursorUp (max 1 (Maybe.withDefault 1 currentCode)) ]
 
                 'B' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ CursorDown (max 1 (Maybe.withDefault 1 currentCode)) ]
 
                 'C' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ CursorForward (max 1 (Maybe.withDefault 1 currentCode)) ]
 
                 'D' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ CursorBackward (max 1 (Maybe.withDefault 1 currentCode)) ]
 
                 'E' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ CursorDown (max 1 (Maybe.withDefault 1 currentCode)), CursorColumn 0 ]
 
                 'F' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ CursorUp (max 1 (Maybe.withDefault 1 currentCode)), CursorColumn 0 ]
 
                 'G' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ CursorColumn (max 0 (Maybe.withDefault 1 currentCode - 1)) ]
 
                 'H' ->
-                    finishEscapeSequence parser hasLink <|
+                    completeEscapeSequence parser hasLink <|
                         cursorPosition (parsedCodes ++ [ currentCode ])
 
                 'J' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ EraseDisplay (eraseMode (Maybe.withDefault 0 currentCode)) ]
 
                 'K' ->
-                    finishEscapeSequence parser hasLink
+                    completeEscapeSequence parser hasLink
                         [ EraseLine (eraseMode (Maybe.withDefault 0 currentCode)) ]
 
                 'f' ->
-                    finishEscapeSequence parser hasLink <|
+                    completeEscapeSequence parser hasLink <|
                         cursorPosition (parsedCodes ++ [ currentCode ])
 
                 's' ->
-                    finishEscapeSequence parser hasLink [ SaveCursorPosition ]
+                    completeEscapeSequence parser hasLink [ SaveCursorPosition ]
 
                 'u' ->
-                    finishEscapeSequence parser hasLink [ RestoreCursorPosition ]
+                    completeEscapeSequence parser hasLink [ RestoreCursorPosition ]
 
                 ';' ->
                     Parser (CSI { marker = marker, parsedCodes = parsedCodes ++ [ currentCode ], currentCode = Nothing }) hasLink model update
@@ -641,54 +425,74 @@ handleCSICommand c marker parsedCodes currentCode hasLink model update parser =
                         -- Any non-digit, non-semicolon character (letter or otherwise) terminates CSI
                         -- Unknown/unrecognized commands are discarded per DEC/VT100 behavior
                         -- Private sequences (with markers) that we don't recognize are also discarded
-                        finishEscapeSequence parser hasLink []
+                        completeEscapeSequence parser hasLink []
 
 
-finishEscapeSequence : Parser a -> Bool -> List Action -> Parser a
-finishEscapeSequence (Parser _ hasLink model update) newHasLink actions =
-    Parser (Unescaped "") newHasLink (List.foldl update model actions) update
+-- SGR (Select Graphic Rendition) Processing
 
 
-cursorPosition : List (Maybe Int) -> List Action
-cursorPosition codes =
-    case codes of
-        [ Nothing, Nothing ] ->
-            [ CursorPosition 1 1 ]
+processSGRCodes : List Int -> List Action
+processSGRCodes list =
+    case list of
+        -- Incomplete 256-color sequences - skip them entirely
+        38 :: 5 :: [] ->
+            []
 
-        [ Nothing ] ->
-            [ CursorPosition 1 1 ]
+        48 :: 5 :: [] ->
+            []
 
-        [ Just row ] ->
-            [ CursorPosition (max 1 row) 1 ]
+        -- Incomplete 24-bit color sequences - skip them entirely
+        38 :: 2 :: _ :: [] ->
+            []
 
-        [ Just row, Nothing ] ->
-            [ CursorPosition (max 1 row) 1 ]
+        38 :: 2 :: _ :: _ :: [] ->
+            []
 
-        [ Nothing, Just col ] ->
-            [ CursorPosition 1 (max 1 col) ]
+        48 :: 2 :: _ :: [] ->
+            []
 
-        [ Just row, Just col ] ->
-            [ CursorPosition (max 1 row) (max 1 col) ]
+        48 :: 2 :: _ :: _ :: [] ->
+            []
 
-        _ ->
+        -- Valid 256-color sequences - only emit action if colorCode succeeds
+        38 :: 5 :: n :: xs ->
+            case colorCode n of
+                Just color ->
+                    SetForeground (Just color) :: processSGRCodes xs
+                Nothing ->
+                    processSGRCodes xs
+
+        48 :: 5 :: n :: xs ->
+            case colorCode n of
+                Just color ->
+                    SetBackground (Just color) :: processSGRCodes xs
+                Nothing ->
+                    processSGRCodes xs
+
+        -- Valid 24-bit color sequences
+        38 :: 2 :: r :: g :: b :: xs ->
+            let
+                c =
+                    clamp 0 255
+            in
+            SetForeground (Just <| Custom (c r) (c g) (c b)) :: processSGRCodes xs
+
+        48 :: 2 :: r :: g :: b :: xs ->
+            let
+                c =
+                    clamp 0 255
+            in
+            SetBackground (Just <| Custom (c r) (c g) (c b)) :: processSGRCodes xs
+
+        n :: xs ->
+            sgrCodeToActions n ++ processSGRCodes xs
+
+        [] ->
             []
 
 
-eraseMode : Int -> EraseMode
-eraseMode code =
-    case code of
-        0 ->
-            EraseToEnd
-
-        1 ->
-            EraseToBeginning
-
-        _ ->
-            EraseAll
-
-
-codeActions : Int -> List Action
-codeActions code =
+sgrCodeToActions : Int -> List Action
+sgrCodeToActions code =
     case code of
         0 ->
             reset
@@ -868,3 +672,201 @@ reset =
     , SetFraktur False
     , SetFramed False
     ]
+
+
+-- Color Conversion
+
+
+{-| Converts a color code to an 8-bit color per
+<https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit>
+-}
+colorCode : Int -> Maybe Color
+colorCode code =
+    case code of
+        0 -> Just Black
+        1 -> Just Red
+        2 -> Just Green
+        3 -> Just Yellow
+        4 -> Just Blue
+        5 -> Just Magenta
+        6 -> Just Cyan
+        7 -> Just White
+        8 -> Just BrightBlack
+        9 -> Just BrightRed
+        10 -> Just BrightGreen
+        11 -> Just BrightYellow
+        12 -> Just BrightBlue
+        13 -> Just BrightMagenta
+        14 -> Just BrightCyan
+        15 -> Just BrightWhite
+
+        _ ->
+            if code < 232 then
+                -- 6x6x6 RGB cube (codes 16-231, 216 colors)
+                let
+                    c = code - 16
+                    b = modBy 6 c
+                    g = modBy 6 (c // 6)
+                    r = c // 36  -- Division by 36 (6²) extracts red component
+                in
+                Just <| Custom (scaleColorComponent r) (scaleColorComponent g) (scaleColorComponent b)
+
+            else if code < 256 then
+                -- Grayscale ramp (codes 232-255, 24 shades)
+                let
+                    gray = (code - 232) * 10 + 8
+                in
+                Just <| Custom gray gray gray
+
+            else
+                Nothing
+
+
+{-| Scales [0,5] -> [0,255] (non-uniformly)
+0 -> 0, 1 -> 95, 2 -> 135, 3 -> 175, 4 -> 215, 5 -> 255
+-}
+scaleColorComponent : Int -> Int
+scaleColorComponent n =
+    if n == 0 then 0 else 55 + n * 40
+
+
+-- Cursor and Screen Control Helpers
+
+
+cursorPosition : List (Maybe Int) -> List Action
+cursorPosition codes =
+    case codes of
+        [ Nothing, Nothing ] ->
+            [ CursorPosition 1 1 ]
+
+        [ Nothing ] ->
+            [ CursorPosition 1 1 ]
+
+        [ Just row ] ->
+            [ CursorPosition (max 1 row) 1 ]
+
+        [ Just row, Nothing ] ->
+            [ CursorPosition (max 1 row) 1 ]
+
+        [ Nothing, Just col ] ->
+            [ CursorPosition 1 (max 1 col) ]
+
+        [ Just row, Just col ] ->
+            [ CursorPosition (max 1 row) (max 1 col) ]
+
+        _ ->
+            []
+
+
+eraseMode : Int -> EraseMode
+eraseMode code =
+    case code of
+        0 ->
+            EraseToEnd
+
+        1 ->
+            EraseToBeginning
+
+        _ ->
+            EraseAll
+
+
+-- Hyperlink Processing (OSC 8)
+
+
+parseOSCSequence : Bool -> String -> (List Action, Bool)
+parseOSCSequence hasActiveLink str =
+    -- Specifically check for the hyperlink end sequence "8;;"
+    if str == "8;;" then
+        if hasActiveLink then
+            ([HyperlinkEnd], False)
+        else
+            ([], False)
+    -- Check for hyperlink start sequence "8;params;uri"
+    else if String.startsWith "8;" str then
+        -- Split only on first 2 semicolons to preserve semicolons in URI
+        case String.split ";" str of
+            "8" :: params :: rest ->
+                -- URI might contain semicolons, so rejoin remaining parts
+                let
+                    uri = String.join ";" rest
+                in
+                if String.isEmpty uri then
+                    -- Invalid format: no URI provided
+                    ([], hasActiveLink)
+                else
+                    let
+                        actions = buildHyperlinkActions params uri
+                    in
+                    (actions, not (List.isEmpty actions))
+            _ ->
+                ([], hasActiveLink)
+    else
+        ([], hasActiveLink)
+
+
+buildHyperlinkActions : String -> String -> List Action
+buildHyperlinkActions params uri =
+    let
+        parsedParams = parseParams params
+        validParams = List.all validateSingleParam parsedParams
+
+        processedUri =
+            if String.any (\c -> Char.toCode c > 127) uri then
+                String.toList uri
+                    |> List.map (\c ->
+                        if Char.toCode c > 127 then
+                            Url.percentEncode (String.fromChar c)
+                        else
+                            String.fromChar c
+                    )
+                    |> String.concat
+            else
+                uri
+    in
+    if not validParams then
+        []
+    else
+        [HyperlinkStart parsedParams processedUri]
+
+
+parseParams : String -> List String
+parseParams params =
+    if String.isEmpty params then
+        []
+    else
+        String.split ":" params
+
+
+isUnreservedChar : Char -> Bool
+isUnreservedChar c =
+    Char.isAlphaNum c || c == '-' || c == '.' || c == '_' || c == '~'
+
+
+isReservedChar : Char -> Bool
+isReservedChar c =
+    String.contains (String.fromChar c) ":/?#[]@!$&'()*+,;="
+
+
+-- Validate that a parameter follows HTTP spec but doesn't contain the
+-- hyperlink protocol delimiters
+validateSingleParam : String -> Bool
+validateSingleParam param =
+    -- For hyperlink parameters, we need to exclude : and ; as they're delimiters
+    -- in the hyperlink protocol, even though they're valid in HTTP URLs
+    String.all (\c ->
+        (isUnreservedChar c || (isReservedChar c && c /= ':' && c /= ';')) &&
+        Char.toCode c >= 32 && Char.toCode c <= 126
+    ) param
+
+
+-- Encoding Helper for Remainder
+
+
+formatCodes : List (Maybe Int) -> String
+formatCodes codes =
+    String.join ";" (List.map (\code ->
+        case code of
+            Nothing -> ""
+            Just num -> String.fromInt num
+    ) codes)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -120,6 +120,255 @@ parsing =
                     , Ansi.Print "not italic/fraktur"
                     ]
                     (Ansi.parse "some text\u{001B}[21mnot bold\u{001B}[22mnot intense\u{001B}[23mnot italic/fraktur")
+        , test "fraktur style" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "normal"
+                    , Ansi.SetFraktur True
+                    , Ansi.Print "fraktur"
+                    , Ansi.SetItalic False
+                    , Ansi.SetFraktur False
+                    , Ansi.Print "not fraktur"
+                    ]
+                    (Ansi.parse "normal\u{001B}[20mfraktur\u{001B}[23mnot fraktur")
+        , test "framed style" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "normal"
+                    , Ansi.SetFramed True
+                    , Ansi.Print "framed"
+                    , Ansi.SetFramed False
+                    , Ansi.Print "not framed"
+                    ]
+                    (Ansi.parse "normal\u{001B}[51mframed\u{001B}[54mnot framed")
+        , test "fast blink (code 6) - not implemented, no action" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "normal"
+                    , Ansi.Print "fast blink"
+                    ]
+                    (Ansi.parse "normal\u{001B}[6mfast blink")
+        , test "all standard foreground colors" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetForeground (Just Ansi.Black)
+                    , Ansi.SetForeground (Just Ansi.Red)
+                    , Ansi.SetForeground (Just Ansi.Green)
+                    , Ansi.SetForeground (Just Ansi.Yellow)
+                    , Ansi.SetForeground (Just Ansi.Blue)
+                    , Ansi.SetForeground (Just Ansi.Magenta)
+                    , Ansi.SetForeground (Just Ansi.Cyan)
+                    , Ansi.SetForeground (Just Ansi.White)
+                    ]
+                    (Ansi.parse "\u{001B}[30m\u{001B}[31m\u{001B}[32m\u{001B}[33m\u{001B}[34m\u{001B}[35m\u{001B}[36m\u{001B}[37m")
+        , test "all standard background colors" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetBackground (Just Ansi.Black)
+                    , Ansi.SetBackground (Just Ansi.Red)
+                    , Ansi.SetBackground (Just Ansi.Green)
+                    , Ansi.SetBackground (Just Ansi.Yellow)
+                    , Ansi.SetBackground (Just Ansi.Blue)
+                    , Ansi.SetBackground (Just Ansi.Magenta)
+                    , Ansi.SetBackground (Just Ansi.Cyan)
+                    , Ansi.SetBackground (Just Ansi.White)
+                    ]
+                    (Ansi.parse "\u{001B}[40m\u{001B}[41m\u{001B}[42m\u{001B}[43m\u{001B}[44m\u{001B}[45m\u{001B}[46m\u{001B}[47m")
+        , test "all bright foreground colors" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetForeground (Just Ansi.BrightBlack)
+                    , Ansi.SetForeground (Just Ansi.BrightRed)
+                    , Ansi.SetForeground (Just Ansi.BrightGreen)
+                    , Ansi.SetForeground (Just Ansi.BrightYellow)
+                    , Ansi.SetForeground (Just Ansi.BrightBlue)
+                    , Ansi.SetForeground (Just Ansi.BrightMagenta)
+                    , Ansi.SetForeground (Just Ansi.BrightCyan)
+                    , Ansi.SetForeground (Just Ansi.BrightWhite)
+                    ]
+                    (Ansi.parse "\u{001B}[90m\u{001B}[91m\u{001B}[92m\u{001B}[93m\u{001B}[94m\u{001B}[95m\u{001B}[96m\u{001B}[97m")
+        , test "all bright background colors" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetBackground (Just Ansi.BrightBlack)
+                    , Ansi.SetBackground (Just Ansi.BrightRed)
+                    , Ansi.SetBackground (Just Ansi.BrightGreen)
+                    , Ansi.SetBackground (Just Ansi.BrightYellow)
+                    , Ansi.SetBackground (Just Ansi.BrightBlue)
+                    , Ansi.SetBackground (Just Ansi.BrightMagenta)
+                    , Ansi.SetBackground (Just Ansi.BrightCyan)
+                    , Ansi.SetBackground (Just Ansi.BrightWhite)
+                    ]
+                    (Ansi.parse "\u{001B}[100m\u{001B}[101m\u{001B}[102m\u{001B}[103m\u{001B}[104m\u{001B}[105m\u{001B}[106m\u{001B}[107m")
+        , test "color reset codes" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetForeground (Just Ansi.Red)
+                    , Ansi.Print "red"
+                    , Ansi.SetForeground Nothing
+                    , Ansi.Print "default fg"
+                    , Ansi.SetBackground (Just Ansi.Blue)
+                    , Ansi.Print "blue bg"
+                    , Ansi.SetBackground Nothing
+                    , Ansi.Print "default bg"
+                    ]
+                    (Ansi.parse "\u{001B}[31mred\u{001B}[39mdefault fg\u{001B}[44mblue bg\u{001B}[49mdefault bg")
+        , test "individual style reset codes" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetUnderline True
+                    , Ansi.Print "underlined"
+                    , Ansi.SetUnderline False
+                    , Ansi.Print "not underlined"
+                    , Ansi.SetBlink True
+                    , Ansi.Print "blinking"
+                    , Ansi.SetBlink False
+                    , Ansi.Print "not blinking"
+                    , Ansi.SetInverted True
+                    , Ansi.Print "inverted"
+                    , Ansi.SetInverted False
+                    , Ansi.Print "not inverted"
+                    , Ansi.SetStrikethrough True
+                    , Ansi.Print "struck"
+                    , Ansi.SetStrikethrough False
+                    , Ansi.Print "not struck"
+                    ]
+                    (Ansi.parse "\u{001B}[4munderlined\u{001B}[24mnot underlined\u{001B}[5mblinking\u{001B}[25mnot blinking\u{001B}[7minverted\u{001B}[27mnot inverted\u{001B}[9mstruck\u{001B}[29mnot struck")
+        , test "cursor movement with default parameters" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorUp 1
+                    , Ansi.CursorDown 1
+                    , Ansi.CursorForward 1
+                    , Ansi.CursorBackward 1
+                    ]
+                    (Ansi.parse "\u{001B}[A\u{001B}[B\u{001B}[C\u{001B}[D")
+        , test "cursor movement with explicit zero defaults to 1" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorUp 1
+                    , Ansi.CursorDown 1
+                    , Ansi.CursorForward 1
+                    , Ansi.CursorBackward 1
+                    ]
+                    (Ansi.parse "\u{001B}[0A\u{001B}[0B\u{001B}[0C\u{001B}[0D")
+        , test "ESC[C is equivalent to ESC[1C and ESC[0C" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorForward 1
+                    , Ansi.CursorForward 1
+                    , Ansi.CursorForward 1
+                    ]
+                    (Ansi.parse "\u{001B}[C\u{001B}[1C\u{001B}[0C")
+        , test "cursor position variations" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorPosition 1 1
+                    , Ansi.CursorPosition 10 1
+                    , Ansi.CursorPosition 1 20
+                    , Ansi.CursorPosition 15 25
+                    ]
+                    (Ansi.parse "\u{001B}[H\u{001B}[10H\u{001B}[;20H\u{001B}[15;25H")
+        , test "cursor position with single row parameter" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorPosition 10 1
+                    , Ansi.CursorPosition 5 1
+                    , Ansi.CursorPosition 1 1
+                    ]
+                    (Ansi.parse "\u{001B}[10H\u{001B}[5H\u{001B}[1H")
+        , test "cursor position with only column parameter" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorPosition 1 10
+                    , Ansi.CursorPosition 1 5
+                    , Ansi.CursorPosition 1 1
+                    ]
+                    (Ansi.parse "\u{001B}[;10H\u{001B}[;5H\u{001B}[;1H")
+        , test "cursor position with 0 values" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorPosition 1 1
+                    , Ansi.CursorPosition 10 1
+                    , Ansi.CursorPosition 1 10
+                    ]
+                    (Ansi.parse "\u{001B}[0;0H\u{001B}[10;0H\u{001B}[0;10H")
+        , test "cursor position with f command" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorPosition 1 1
+                    , Ansi.CursorPosition 5 10
+                    ]
+                    (Ansi.parse "\u{001B}[f\u{001B}[5;10f")
+        , test "cursor column movement" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorColumn 0
+                    , Ansi.CursorColumn 9
+                    , Ansi.CursorColumn 49
+                    ]
+                    (Ansi.parse "\u{001B}[G\u{001B}[10G\u{001B}[50G")
+        , test "cursor down with column reset (E)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorDown 1
+                    , Ansi.CursorColumn 0
+                    , Ansi.CursorDown 3
+                    , Ansi.CursorColumn 0
+                    ]
+                    (Ansi.parse "\u{001B}[E\u{001B}[3E")
+        , test "cursor up with column reset (F)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.CursorUp 1
+                    , Ansi.CursorColumn 0
+                    , Ansi.CursorUp 2
+                    , Ansi.CursorColumn 0
+                    ]
+                    (Ansi.parse "\u{001B}[F\u{001B}[2F")
+        , test "erase display modes" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.EraseDisplay Ansi.EraseToEnd
+                    , Ansi.EraseDisplay Ansi.EraseToBeginning
+                    , Ansi.EraseDisplay Ansi.EraseAll
+                    , Ansi.EraseDisplay Ansi.EraseAll
+                    ]
+                    (Ansi.parse "\u{001B}[J\u{001B}[1J\u{001B}[2J\u{001B}[3J")
+        , test "erase line modes" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.EraseLine Ansi.EraseToEnd
+                    , Ansi.EraseLine Ansi.EraseToBeginning
+                    , Ansi.EraseLine Ansi.EraseAll
+                    , Ansi.EraseLine Ansi.EraseAll
+                    ]
+                    (Ansi.parse "\u{001B}[K\u{001B}[1K\u{001B}[2K\u{001B}[3K")
+        , test "combined style codes" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetBold True
+                    , Ansi.SetItalic True
+                    , Ansi.SetForeground (Just Ansi.Red)
+                    , Ansi.Print "styled"
+                    ]
+                    (Ansi.parse "\u{001B}[1;3;31mstyled")
+        , test "all styles combined in single sequence" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetBold True
+                    , Ansi.SetFaint True
+                    , Ansi.SetItalic True
+                    , Ansi.SetUnderline True
+                    , Ansi.SetBlink True
+                    , Ansi.SetInverted True
+                    , Ansi.SetStrikethrough True
+                    , Ansi.SetFraktur True
+                    , Ansi.SetFramed True
+                    , Ansi.SetForeground (Just Ansi.Cyan)
+                    , Ansi.SetBackground (Just Ansi.Magenta)
+                    ]
+                    (Ansi.parse "\u{001B}[1;2;3;4;5;7;9;20;51;36;45m")
         , test "carriage returns and linebreaks" <|
             \() ->
                 Expect.equal
@@ -201,6 +450,70 @@ parsing =
                       [ Ansi.Print "foo", Ansi.Print "bar" ]
                     ]
                     [ invalid1, invalid2, unknown ]
+        , test "malformed 256-color sequences" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "incomplete"
+                    , Ansi.Print "ext"
+                    ]
+                    (Ansi.parse "before\u{001B}[38;5mincomplete\u{001B}[48;5text")
+        , test "malformed 24-bit color sequences" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "missing g and b"
+                    , Ansi.Print "missing b"
+                    ]
+                    (Ansi.parse "before\u{001B}[38;2;255mmissing g and b\u{001B}[48;2;100;200mmissing b")
+        , test "Concourse CI log sequence with unknown commands" <|
+            \() ->
+                -- Real-world case: ESC[r ESC[m ESC(B ESC[?1003l ESC[?1006l ESC[?2004l ESC[1;1H ESC[1;24r ESC[1;1H
+                -- Unknown commands (r, ?...l) should be discarded, only recognized commands output
+                Expect.equal
+                    ([ Ansi.SetForeground Nothing
+                    , Ansi.SetBackground Nothing
+                    , Ansi.SetBold False
+                    , Ansi.SetFaint False
+                    , Ansi.SetItalic False
+                    , Ansi.SetUnderline False
+                    , Ansi.SetBlink False
+                    , Ansi.SetInverted False
+                    , Ansi.SetStrikethrough False
+                    , Ansi.SetFraktur False
+                    , Ansi.SetFramed False
+                    , Ansi.Print "(B"
+                    , Ansi.CursorPosition 1 1
+                    , Ansi.CursorPosition 1 1
+                    ] )
+                    (Ansi.parse "\u{001B}[r\u{001B}[m\u{001B}(B\u{001B}[?1003l\u{001B}[?1006l\u{001B}[?2004l\u{001B}[1;1H\u{001B}[1;24r\u{001B}[1;1H")
+        , test "multiple SGR parameters in one sequence" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetBold True
+                    , Ansi.SetForeground (Just Ansi.Red)
+                    , Ansi.SetBackground (Just Ansi.Blue)
+                    , Ansi.Print "styled"
+                    , Ansi.SetBold True
+                    , Ansi.SetItalic True
+                    , Ansi.SetUnderline True
+                    , Ansi.Print "multi-style"
+                    ]
+                    (Ansi.parse "\u{001B}[1;31;44mstyled\u{001B}[1;3;4mmulti-style")
+        , test "out-of-range SGR parameters are ignored" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "normal"
+                    , Ansi.Print "unchanged"
+                    ]
+                    (Ansi.parse "normal\u{001B}[999munchanged")
+        , test "out-of-range 256-color values" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}[38;5;256mafter")
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -514,6 +514,94 @@ parsing =
                     , Ansi.Print "after"
                     ]
                     (Ansi.parse "before\u{001B}[38;5;256mafter")
+        , test "CSI with < parameter marker is properly ignored" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}[<1;2;3mafter")
+        , test "CSI with = parameter marker is properly ignored" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}[=5cafter")
+        , test "CSI with > parameter marker is properly ignored" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}[>cafter")
+        , test "CSI with ? parameter marker is properly ignored" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}[?1003lafter")
+        , test "CSI < marker does not affect normal sequences" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetForeground (Just Ansi.Red)
+                    , Ansi.Print "red"
+                    , Ansi.Print "ignored"
+                    , Ansi.SetForeground (Just Ansi.Blue)
+                    , Ansi.Print "blue"
+                    ]
+                    (Ansi.parse "\u{001B}[31mred\u{001B}[<10;20Mignored\u{001B}[34mblue")
+        , test "CSI > marker with parameters is properly ignored" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.Print "more"
+                    ]
+                    (Ansi.parse "text\u{001B}[>1;2;3;4cmore")
+        , test "CSI = marker with parameters is properly ignored" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.Print "more"
+                    ]
+                    (Ansi.parse "text\u{001B}[=7;8;9cmore")
+        , test "CSI ? marker in middle of sequence is ignored" <|
+            \() ->
+                -- '?' should only be valid at start; if it appears after digits, ignore the whole sequence
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.Print "more"
+                    ]
+                    (Ansi.parse "text\u{001B}[1?2mmore")
+        , test "Multiple CSI sequences with different markers" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SetBold True
+                    , Ansi.Print "bold"
+                    , Ansi.Print "ignored1"
+                    , Ansi.SetForeground (Just Ansi.Green)
+                    , Ansi.Print "green"
+                    , Ansi.Print "ignored2"
+                    , Ansi.SetBlink True
+                    , Ansi.Print "blink"
+                    ]
+                    (Ansi.parse "\u{001B}[1mbold\u{001B}[<5Mignored1\u{001B}[32mgreen\u{001B}[>1cignored2\u{001B}[5mblink")
+        , test "CSI marker in remainder (incomplete sequence)" <|
+            \() ->
+                -- Incomplete sequence with marker should be preserved in Remainder
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.Remainder "\u{001B}[<12"
+                    ]
+                    (Ansi.parse "text\u{001B}[<12")
+        , test "CSI marker followed by semicolon" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}[>;1;2mafter")
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -646,6 +646,92 @@ parsing =
                     , Ansi.Print "text"
                     ]
                     (Ansi.parse "\u{001B}[1mbold\u{001B}(Btext")
+        , test "ESC 7 saves cursor position" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.SaveCursorPosition
+                    , Ansi.Print "more"
+                    ]
+                    (Ansi.parse "text\u{001B}7more")
+        , test "ESC 8 restores cursor position" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.RestoreCursorPosition
+                    , Ansi.Print "more"
+                    ]
+                    (Ansi.parse "text\u{001B}8more")
+        , test "ESC M reverse index (cursor up)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.CursorUp 1
+                    , Ansi.Print "more"
+                    ]
+                    (Ansi.parse "text\u{001B}Mmore")
+        , test "ESC D index (cursor down)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.CursorDown 1
+                    , Ansi.Print "more"
+                    ]
+                    (Ansi.parse "text\u{001B}Dmore")
+        , test "ESC E next line (CR + LF)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "text"
+                    , Ansi.CarriageReturn
+                    , Ansi.Linebreak
+                    , Ansi.Print "more"
+                    ]
+                    (Ansi.parse "text\u{001B}Emore")
+        , test "ESC = keypad application mode (ignored)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}=after")
+        , test "ESC > keypad numeric mode (ignored)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}>after")
+        , test "ESC c full reset (ignored)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}cafter")
+        , test "ESC H tab set (ignored)" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.Print "before"
+                    , Ansi.Print "after"
+                    ]
+                    (Ansi.parse "before\u{001B}Hafter")
+        , test "multiple single-char escapes in sequence" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SaveCursorPosition
+                    , Ansi.Print "text"
+                    , Ansi.RestoreCursorPosition
+                    ]
+                    (Ansi.parse "\u{001B}7text\u{001B}8")
+        , test "single-char escapes mixed with CSI" <|
+            \() ->
+                Expect.equal
+                    [ Ansi.SaveCursorPosition
+                    , Ansi.SetBold True
+                    , Ansi.Print "bold"
+                    , Ansi.RestoreCursorPosition
+                    ]
+                    (Ansi.parse "\u{001B}7\u{001B}[1mbold\u{001B}8")
         ]
 
 


### PR DESCRIPTION
- Consume and ignore private markers
- Consume and ignore charset designation sequences
- Add single-character escape sequence support

- Fix cursor movement commands (A,B,C,D,E,F) to treat explicit 0 as 1 per ANSI spec
- Fix cursorPosition to handle single parameter case (e.g., ESC[10H)
- Fix cursorPosition to treat 0 as 1 for both row and column (1-indexed positions)
- Fix incomplete pattern matching and range validation
- Add comprehensive tests for all ANSI control codes:
  - All 16 standard and bright foreground/background colors (30-37, 40-47, 90-97, 100-107)
  - Color reset codes (39, 49)
  - Fraktur style (20, 23)
  - Framed style (51, 54)
  - Individual style resets (24, 25, 27, 29)
  - Cursor movement edge cases (default params, explicit 0, equivalence tests)
  - All cursor position variations
  - All erase display/line modes
  - Combined style sequences